### PR TITLE
Hydrate method and Data mapper with configurable

### DIFF
--- a/src/Actions/DataMapperAction.php
+++ b/src/Actions/DataMapperAction.php
@@ -2,7 +2,6 @@
 
 namespace KoalaFacade\DiamondConsole\Actions;
 
-use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\Source;
 use CuyZ\Valinor\MapperBuilder;
 use KoalaFacade\DiamondConsole\Contracts\DataMapper;

--- a/src/Actions/DataMapperAction.php
+++ b/src/Actions/DataMapperAction.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace KoalaFacade\DiamondConsole\Actions;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Source\Source;
+use CuyZ\Valinor\MapperBuilder;
+use KoalaFacade\DiamondConsole\Contracts\DataMapper;
+use KoalaFacade\DiamondConsole\Foundation\Action;
+
+readonly class DataMapperAction extends Action implements DataMapper
+{
+    /**
+     * @throws MappingError
+     * @param array $data
+     * @return $this|DataMapperAction
+     * @param class-string | string $signature
+     */
+    public function execute(string $signature, array $data): mixed
+    {
+        return (new MapperBuilder)
+            ->mapper()
+            ->map(
+                signature: $signature,
+                source: Source::array(data: $data)->camelCaseKeys()
+            );
+    }
+}

--- a/src/Actions/DataMapperAction.php
+++ b/src/Actions/DataMapperAction.php
@@ -10,12 +10,6 @@ use KoalaFacade\DiamondConsole\Foundation\Action;
 
 readonly class DataMapperAction extends Action implements DataMapper
 {
-    /**
-     * @throws MappingError
-     * @param array $data
-     * @return $this|DataMapperAction
-     * @param class-string | string $signature
-     */
     public function execute(string $signature, array $data): mixed
     {
         return (new MapperBuilder)

--- a/src/Contracts/DataMapper.php
+++ b/src/Contracts/DataMapper.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace KoalaFacade\DiamondConsole\Contracts;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use KoalaFacade\DiamondConsole\Actions\DataMapperAction;
+
+interface DataMapper
+{
+    /**
+     * @throws MappingError
+     * @param array $data
+     * @return $this|DataMapperAction
+     * @param class-string | string $signature
+     */
+    public function execute(string $signature, array $data): mixed;
+}

--- a/src/Contracts/DataMapper.php
+++ b/src/Contracts/DataMapper.php
@@ -3,15 +3,14 @@
 namespace KoalaFacade\DiamondConsole\Contracts;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use KoalaFacade\DiamondConsole\Actions\DataMapperAction;
 
 interface DataMapper
 {
     /**
+     * @param  array<array-key, mixed>  $data
+     * @param  class-string | string  $signature
+     *
      * @throws MappingError
-     * @param array<array-key, mixed> $data
-     * @return mixed
-     * @param class-string | string $signature
      */
     public function execute(string $signature, array $data): mixed;
 }

--- a/src/Contracts/DataMapper.php
+++ b/src/Contracts/DataMapper.php
@@ -9,8 +9,8 @@ interface DataMapper
 {
     /**
      * @throws MappingError
-     * @param array $data
-     * @return $this|DataMapperAction
+     * @param array<array-key, mixed> $data
+     * @return mixed
      * @param class-string | string $signature
      */
     public function execute(string $signature, array $data): mixed;

--- a/src/DiamondConsoleServiceProvider.php
+++ b/src/DiamondConsoleServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use KoalaFacade\DiamondConsole\Actions\DataMapperAction;
+use KoalaFacade\DiamondConsole\Contracts\DataMapper;
 use Symfony\Component\Finder\SplFileInfo;
 
 class DiamondConsoleServiceProvider extends ServiceProvider
@@ -20,6 +22,8 @@ class DiamondConsoleServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(path: __DIR__ . '/../config/diamond.php', key: 'diamond');
+
+        $this->app->singletonIf(abstract: DataMapper::class, concrete: DataMapperAction::class);
     }
 
     protected function registerPublishers(): void

--- a/src/Foundation/Action.php
+++ b/src/Foundation/Action.php
@@ -2,7 +2,7 @@
 
 namespace KoalaFacade\DiamondConsole\Foundation;
 
-readonly abstract class Action
+abstract readonly class Action
 {
     /**
      * Resolve an action class

--- a/src/Foundation/DataTransferObject.php
+++ b/src/Foundation/DataTransferObject.php
@@ -69,8 +69,6 @@ abstract readonly class DataTransferObject
 
     /**
      * Die and dump the current Data.
-     *
-     * @return never
      */
     public function dd(): never
     {
@@ -79,9 +77,6 @@ abstract readonly class DataTransferObject
 
     /**
      * Abilities to orchestrate the Data
-     *
-     * @param mixed ...$values
-     * @return static
      */
     public function recycle(mixed ...$values): static
     {

--- a/src/Foundation/DataTransferObject.php
+++ b/src/Foundation/DataTransferObject.php
@@ -2,14 +2,11 @@
 
 namespace KoalaFacade\DiamondConsole\Foundation;
 
-use CuyZ\Valinor\Mapper\MappingError;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Tappable;
-use KoalaFacade\DiamondConsole\Contracts\DataMapper;
 use KoalaFacade\DiamondConsole\Foundation\DataTransferObject\HasResolvable;
 use Spatie\Cloneable\Cloneable;
 
@@ -91,33 +88,6 @@ abstract readonly class DataTransferObject
         } else {
             $instance = $this->with(...$values);
         }
-
-        return $instance;
-    }
-
-    /**
-     * @param  array<TKey, TValue> | Model  $data
-     *
-     * Hydrate incoming data to resolve unstructured data
-     *
-     * @throws MappingError
-     *
-     * @template TKey of array-key
-     * @template TValue
-     */
-    public static function hydrate(array | Model $data): static
-    {
-        /** @var DataMapper $dataMapper */
-        $dataMapper = resolve(name: DataMapper::class);
-
-        /** @var static $instance */
-        $instance = $dataMapper->execute(
-            signature: static::class,
-            data: match (true) {
-                $data instanceof Model => $data->attributesToArray(),
-                default => $data
-            }
-        );
 
         return $instance;
     }

--- a/src/Foundation/DataTransferObject/HasResolvable.php
+++ b/src/Foundation/DataTransferObject/HasResolvable.php
@@ -4,10 +4,12 @@ namespace KoalaFacade\DiamondConsole\Foundation\DataTransferObject;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\MapperBuilder;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use KoalaFacade\DiamondConsole\Contracts\DataMapper;
 
 trait HasResolvable
 {
@@ -39,6 +41,28 @@ trait HasResolvable
     }
 
     /**
+     * @throws MappingError
+     * @return HasResolvable
+     * @param array<TKey, TValue> | Model $data
+     *
+     * Hydrate incoming data to resolve unstructured data
+     *
+     * @template TKey of array-key
+     * @template TValue
+     */
+    public static function hydrate(array | Model $data): static
+    {
+        return resolve(name: DataMapper::class)
+            ->execute(
+                signature: static::class,
+                data: match (true) {
+                    $data instanceof Model => $data->attributesToArray(),
+                    default => $data
+                }
+            );
+    }
+
+    /**
      * Resolve unstructured data from array
      *
      * @template TKey of array-key
@@ -47,6 +71,8 @@ trait HasResolvable
      * @param  array<TKey, TValue>  $data
      *
      * @throws MappingError
+     *
+     * @deprecated use hydrate(array $data) instead
      */
     public static function resolve(array $data): static
     {
@@ -92,6 +118,8 @@ trait HasResolvable
     }
 
     /**
+     * @deprecated
+     *
      * Resolve all array key form according the config
      *
      * @template TArrayKey of array-key

--- a/src/Foundation/DataTransferObject/HasResolvable.php
+++ b/src/Foundation/DataTransferObject/HasResolvable.php
@@ -40,33 +40,6 @@ trait HasResolvable
     }
 
     /**
-     * @param  array<TKey, TValue> | Model  $data
-     *
-     * Hydrate incoming data to resolve unstructured data
-     *
-     * @throws MappingError
-     *
-     * @template TKey of array-key
-     * @template TValue
-     */
-    public static function hydrate(array | Model $data): static
-    {
-        /** @var DataMapper $dataMapper */
-        $dataMapper = resolve(name: DataMapper::class);
-
-        /** @var static $instance */
-        $instance = $dataMapper->execute(
-            signature: static::class,
-            data: match (true) {
-                $data instanceof Model => $data->attributesToArray(),
-                default => $data
-            }
-        );
-
-        return $instance;
-    }
-
-    /**
      * Resolve unstructured data from array
      *
      * @template TKey of array-key
@@ -80,12 +53,7 @@ trait HasResolvable
      */
     public static function resolve(array $data): static
     {
-        /** @var static $instance */
-        $instance = (new MapperBuilder())
-            ->mapper()
-            ->map(signature: static::class, source: static::resolveTheArrayKeyForm(data: $data));
-
-        return $instance;
+        return static::hydrate($data);
     }
 
     /**

--- a/src/Foundation/DataTransferObject/HasResolvable.php
+++ b/src/Foundation/DataTransferObject/HasResolvable.php
@@ -128,4 +128,31 @@ trait HasResolvable
     {
         return Str::camel(value: $key);
     }
+
+    /**
+     * @param  array<TKey, TValue> | Model  $data
+     *
+     * Hydrate incoming data to resolve unstructured data
+     *
+     * @throws MappingError
+     *
+     * @template TKey of array-key
+     * @template TValue
+     */
+    public static function hydrate(array | Model $data): static
+    {
+        /** @var DataMapper $dataMapper */
+        $dataMapper = resolve(name: DataMapper::class);
+
+        /** @var static $instance */
+        $instance = $dataMapper->execute(
+            signature: static::class,
+            data: match (true) {
+                $data instanceof Model => $data->attributesToArray(),
+                default => $data
+            }
+        );
+
+        return $instance;
+    }
 }

--- a/src/Foundation/DataTransferObject/HasResolvable.php
+++ b/src/Foundation/DataTransferObject/HasResolvable.php
@@ -130,7 +130,7 @@ trait HasResolvable
     }
 
     /**
-     * @param  array<TKey, TValue> | Model  $data
+     * @param  array<TKey, TValue> $data
      *
      * Hydrate incoming data to resolve unstructured data
      *
@@ -139,7 +139,7 @@ trait HasResolvable
      * @template TKey of array-key
      * @template TValue
      */
-    public static function hydrate(array | Model $data): static
+    public static function hydrate(array $data): static
     {
         /** @var DataMapper $dataMapper */
         $dataMapper = resolve(name: DataMapper::class);
@@ -147,10 +147,7 @@ trait HasResolvable
         /** @var static $instance */
         $instance = $dataMapper->execute(
             signature: static::class,
-            data: match (true) {
-                $data instanceof Model => $data->attributesToArray(),
-                default => $data
-            }
+            data: $data
         );
 
         return $instance;

--- a/src/Foundation/DataTransferObject/HasResolvable.php
+++ b/src/Foundation/DataTransferObject/HasResolvable.php
@@ -42,7 +42,7 @@ trait HasResolvable
 
     /**
      * @throws MappingError
-     * @return HasResolvable
+     * @return static
      * @param array<TKey, TValue> | Model $data
      *
      * Hydrate incoming data to resolve unstructured data
@@ -52,14 +52,19 @@ trait HasResolvable
      */
     public static function hydrate(array | Model $data): static
     {
-        return resolve(name: DataMapper::class)
-            ->execute(
-                signature: static::class,
-                data: match (true) {
-                    $data instanceof Model => $data->attributesToArray(),
-                    default => $data
-                }
-            );
+        /** @var DataMapper $dataMapper */
+        $dataMapper = resolve(name: DataMapper::class);
+
+        /** @var static $instance */
+        $instance = $dataMapper->execute(
+            signature: static::class,
+            data: match (true) {
+                $data instanceof Model => $data->attributesToArray(),
+                default => $data
+            }
+        );
+
+        return $instance;
     }
 
     /**

--- a/src/Foundation/DataTransferObject/HasResolvable.php
+++ b/src/Foundation/DataTransferObject/HasResolvable.php
@@ -4,7 +4,6 @@ namespace KoalaFacade\DiamondConsole\Foundation\DataTransferObject;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\MapperBuilder;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Arr;
@@ -41,11 +40,11 @@ trait HasResolvable
     }
 
     /**
-     * @throws MappingError
-     * @return static
-     * @param array<TKey, TValue> | Model $data
+     * @param  array<TKey, TValue> | Model  $data
      *
      * Hydrate incoming data to resolve unstructured data
+     *
+     * @throws MappingError
      *
      * @template TKey of array-key
      * @template TValue

--- a/tests/Unit/DataTransferObjects/DataTransferObjectTest.php
+++ b/tests/Unit/DataTransferObjects/DataTransferObjectTest.php
@@ -164,6 +164,7 @@ it(description: 'can recycle the data with conditional')
     });
 
 it(description: 'can hydrate data')
+    ->group('unit', 'dto')
     ->tap(callable: function () {
         $data = UserData::hydrate(data: [
             'gender' => GenderEnum::Female,
@@ -173,6 +174,7 @@ it(description: 'can hydrate data')
     });
 
 it(description: 'can change hydrate data mapper implementation')
+    ->group('unit', 'dto')
     ->tap(callable: function () {
         app()->instance(
             abstract: DataMapper::class,

--- a/tests/Unit/DataTransferObjects/DataTransferObjectTest.php
+++ b/tests/Unit/DataTransferObjects/DataTransferObjectTest.php
@@ -85,7 +85,7 @@ it(description: 'can recycle the data directly')
     )
     ->tap(callable: function () {
         $data = UserData::resolve(data: [
-            'name' => 'Kevin'
+            'name' => 'Kevin',
         ]);
 
         $addresses = [
@@ -109,7 +109,7 @@ it(description: 'can recycle the data with callback')
     )
     ->tap(callable: function () {
         $data = UserData::resolve(data: [
-            'name' => 'Kevin'
+            'name' => 'Kevin',
         ]);
 
         $addresses = [
@@ -133,7 +133,7 @@ it(description: 'can recycle the data with conditional')
     )
     ->tap(callable: function () {
         $data = UserData::resolve(data: [
-            'name' => 'Kevin'
+            'name' => 'Kevin',
         ]);
 
         $roleData = new RoleData(name: 'Maintainer');
@@ -176,7 +176,8 @@ it(description: 'can change hydrate data mapper implementation')
     ->tap(callable: function () {
         app()->instance(
             abstract: DataMapper::class,
-            instance: new class implements DataMapper {
+            instance: new class implements DataMapper
+            {
                 public function execute(string $signature, array $data): mixed
                 {
                     return new $signature(
@@ -189,7 +190,6 @@ it(description: 'can change hydrate data mapper implementation')
         $data = UserData::hydrate(data: [
             'gender' => GenderEnum::Female,
         ]);
-
 
         expect(value: $data->gender)->toBe(expected: GenderEnum::Female);
     });

--- a/tests/Unit/DataTransferObjects/DataTransferObjectTest.php
+++ b/tests/Unit/DataTransferObjects/DataTransferObjectTest.php
@@ -2,6 +2,7 @@
 
 use Composer\InstalledVersions;
 use Illuminate\Support\Arr;
+use KoalaFacade\DiamondConsole\Contracts\DataMapper;
 use Tests\Unit\DataTransferObjects\Fixtures\GenderEnum;
 use Tests\Unit\DataTransferObjects\Fixtures\RoleData;
 use Tests\Unit\DataTransferObjects\Fixtures\UserData;
@@ -160,4 +161,35 @@ it(description: 'can recycle the data with conditional')
             ->tap(
                 callback: fn (UserData $data) => expect($roleData->name)->toBe($roleData->name)
             );
+    });
+
+it(description: 'can hydrate data')
+    ->tap(callable: function () {
+        $data = UserData::hydrate(data: [
+            'gender' => GenderEnum::Female,
+        ]);
+
+        expect(value: $data->gender)->toBe(expected: GenderEnum::Female);
+    });
+
+it(description: 'can change hydrate data mapper implementation')
+    ->tap(callable: function () {
+        app()->instance(
+            abstract: DataMapper::class,
+            instance: new class implements DataMapper {
+                public function execute(string $signature, array $data): mixed
+                {
+                    return new $signature(
+                        gender: $data['gender']
+                    );
+                }
+            }
+        );
+
+        $data = UserData::hydrate(data: [
+            'gender' => GenderEnum::Female,
+        ]);
+
+
+        expect(value: $data->gender)->toBe(expected: GenderEnum::Female);
     });


### PR DESCRIPTION
By this method we able to make the clear of context why this method exists and implement of DataMapper Contract we let client configure how they will resolve an array, by default we fallback to the DataMapperAction to resolve the data as below:

- Support Model to attributes of array
- Setupable how data will resolve and have an fallback
- Drop support for resolve() and resolveTheArrayKeyForm() method

<img width="585" alt="image" src="https://user-images.githubusercontent.com/56016477/228321397-66b4d001-5792-4455-9df0-cfdbeadcdabc.png">

the way of use is same as resolve(), by this feature we mark resolve() as deprecated method and will be remove in next major changes

<img width="662" alt="image" src="https://user-images.githubusercontent.com/56016477/228321687-d8260d4f-248a-46c4-b0da-c81960b2f386.png">
